### PR TITLE
main, spread: improve reporting of allocation errors

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -65,15 +65,12 @@ suites:
 
     prepare: |
       apt update
-      apt install go rustup -yy
+      apt install golang-go rustup -yy
       go install github.com/snapcore/spread/cmd/spread@latest
       ln -svf ~/go/bin/spread /usr/local/bin/
 
       rustup default stable
-      cargo install --path "$SPREAD_PATH" --root /usr/local
-
-      ln -svf $SPREAD_PATH/target/debug/spread-adhoc-allocator \
-          /usr/local/bin/
+      cargo install --debug --path "$SPREAD_PATH" --root /usr/local
 
       # make sure --help works
       spread-adhoc-allocator --help

--- a/spread.yaml
+++ b/spread.yaml
@@ -45,6 +45,9 @@ backends:
       - ubuntu-core-24-64:
           username: ubuntu
           password: ubuntu
+      - unsupported-for-tests:
+          username: ubuntu
+          password: ubuntu
 
   lxd:
     type: lxd

--- a/spread.yaml
+++ b/spread.yaml
@@ -13,16 +13,16 @@ backends:
       stderr_out="$(mktemp)"
       trap "rv=\$?; rm "$stderr_out"; exit \$rv" EXIT
 
-      if address="$(spread-adhoc-allocator allocate \
+      if out="$(spread-adhoc-allocator allocate \
                  "$SPREAD_SYSTEM" \
                  ubuntu \
                  "$SPREAD_SYSTEM_PASSWORD" 2>"$stderr_out")"; then
-        ADDRESS "$address"
+        ADDRESS "$out"
       else
         echo "allocation failed, log:"
         cat "$stderr_out"
         # FATAL does not work with multiline output
-        FATAL "cannot allocate: $(tail -1 "$stderr_out")"
+        FATAL "$out"
       fi
     discard: |
       spread-adhoc-allocator deallocate "$SPREAD_SYSTEM_ADDRESS"

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ enum Command {
     Version,
 }
 
-fn main() -> Result<()> {
+fn try_main() -> Result<()> {
     simple_logger::init_with_level(log::Level::Trace).unwrap();
 
     let cli = Cli::parse();
@@ -104,5 +104,16 @@ fn main() -> Result<()> {
             Ok(())
         }
         None => Err(anyhow!("no command provided, see --help")),
+    }
+}
+
+use std::process;
+
+fn main() -> process::ExitCode {
+    if let Err(err) = try_main() {
+        println!("{:#}", err);
+        process::ExitCode::FAILURE
+    } else {
+        process::ExitCode::SUCCESS
     }
 }

--- a/tests/failed-alloc/task.yaml
+++ b/tests/failed-alloc/task.yaml
@@ -1,0 +1,9 @@
+summary: Check failed allocation scenario
+
+execute: |
+  cd "$SPREAD_PATH" || exit 1
+  if spread -v adhoc-lxd:unsupported-for-tests:examples/ > out.log 2>&1 ; then
+      echo "Unexpected success"
+      exit 1
+  fi
+  MATCH 'Cannot allocate adhoc-lxd:unsupported-for-tests: cannot allocate: system "unsupported-for-tests" not found in configuration' < out.log


### PR DESCRIPTION
Print allocation errors to stdout, such that they can be easily reported to spread through `FATAL "<msg>"` helper.