### PR TITLE
conf: spread-lxd: drop Fedora 41 tar workaround

### DIFF
--- a/spread-lxd.yaml
+++ b/spread-lxd.yaml
@@ -72,5 +72,3 @@ setup:
       fi
     # reload sshd configuration
     - killall -HUP sshd || true
-    # Fedora images are bare bones, not even tar is included
-    - ( . /etc/os-release; if [ "$ID" == "fedora" ]; then dnf install tar -y ; fi)


### PR DESCRIPTION
A fix for https://github.com/canonical/lxd/issues/14974 landed in lxd-imagebuilder and the images have been updated. Workaround is not needed anymore.